### PR TITLE
Fix build for darwin

### DIFF
--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -42,3 +42,38 @@ jobs:
       run: |
         nix fmt
         git diff --exit-code
+
+  nix-flake-check-darwin:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v30
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: DeterminateSystems/magic-nix-cache-action@v8
+
+    - name: Flake metadata
+      run: |
+        nix flake metadata
+        nix flake show
+
+    - name: Flake check
+      run: |
+        nix flake check -L
+
+    - name: Run qemu-espressif
+      run: |
+        nix run . -- --version
+
+    - name: Run qemu-esp32
+      run: |
+        nix run .#qemu-esp32 -- --version
+
+    - name: Run qemu-esp32c3
+      run: |
+        nix run .#qemu-esp32c3 -- --version
+
+    - name: Formatter check
+      run: |
+        nix fmt
+        git diff --exit-code

--- a/packages/qemu-espressif/default.nix
+++ b/packages/qemu-espressif/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   qemu,
   libgcrypt,
+  SDL2,
   enableEsp32 ? true,
   enableEsp32c3 ? true,
 }:
@@ -16,8 +17,7 @@ let
     owner = "qemu-project";
     repo = "keycodemapdb";
     rev = "f5772a62ec52591ff6870b7e8ef32482371f22c6";
-    hash = "sha256-EQrnBAXQhllbVCHpOsgREzYGncMUPEIoWFGnjo+hrH4=";
-    fetchSubmodules = true;
+    hash = "sha256-GbZ5mrUYLXMi0IX4IZzles0Oyc095ij2xAsiLNJwfKQ=";
   };
 
   berkeley-softfloat-3 = fetchFromGitLab {
@@ -25,7 +25,6 @@ let
     repo = "berkeley-softfloat-3";
     rev = "b64af41c3276f97f0e181920400ee056b9c88037";
     hash = "sha256-Yflpx+mjU8mD5biClNpdmon24EHg4aWBZszbOur5VEA=";
-    fetchSubmodules = true;
   };
 
   berkeley-testfloat-3 = fetchFromGitLab {
@@ -33,7 +32,6 @@ let
     repo = "berkeley-testfloat-3";
     rev = "e7af9751d9f9fd3b47911f51a5cfd08af256a9ab";
     hash = "sha256-inQAeYlmuiRtZm37xK9ypBltCJ+ycyvIeIYZK8a+RYU=";
-    fetchSubmodules = true;
   };
 
   targets =
@@ -61,7 +59,8 @@ qemu.overrideAttrs (oldAttrs: {
     hash = "sha256-6RX7wGv1Lkxw9ZlLDlQ/tlq/V8QbVzcb27NTr2uwePI=";
   };
 
-  buildInputs = oldAttrs.buildInputs ++ [ libgcrypt ];
+  buildInputs =
+    oldAttrs.buildInputs ++ [ libgcrypt ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ SDL2 ];
 
   postPatch =
     oldAttrs.postPatch
@@ -98,7 +97,6 @@ qemu.overrideAttrs (oldAttrs: {
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--cross-prefix=${stdenv.cc.targetPrefix}"
-    "--enable-linux-aio"
 
     # Flags taken from the instructions for the Espressif fork
     # Based on https://github.com/espressif/esp-toolchain-docs/blob/main/qemu/esp32/README.md
@@ -116,6 +114,8 @@ qemu.overrideAttrs (oldAttrs: {
     "--disable-capstone"
     "--disable-vnc"
     "--disable-gtk"
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    "--enable-linux-aio"
   ];
 
   meta = oldAttrs.meta // {


### PR DESCRIPTION
Thanks so much for your work on this -- with these changes I'm able to build and run on aarch64-darwin!

The gitlab fetchers were not able to handle some kind of redirect or proxy with the qemu sources; it seems to work find if I remove the fetching of submodules. I manually poked around, and I'm pretty sure that none of the sources listed actually *have* submodules (manually cloning and investigated `git submodule status`, and it seems to build and run fine without those.

I'm also getting a different hash for qemu (at the same rev) -- not sure why.

Other than that it's pretty straightforward.