### PR TITLE
Make the minimal build the default and only available build

### DIFF
--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -36,16 +36,14 @@ jobs:
     - name: Build from overlay without flake
       run: |
         for v in espressif esp32 esp32c3; do
-          for m in "" "-minimal"; do
-            NIX_PATH=$NIX_PATH:nixpkgs-overlays=$(pwd)/overlays.nix \
-            nix-build \
-              https://github.com/NixOS/nixpkgs/archive/$(grep rev flake.lock | sed 's/^.*: //' | sed -e 's/"//g' -e 's/,//').tar.gz \
-              --attr qemu-${v}${m}
-            for exe in ./result/bin/qemu-system-*; do
-              echo ${exe}
-              ${exe} --version
-              ${exe} --machine help
-            done
+          NIX_PATH=$NIX_PATH:nixpkgs-overlays=$(pwd)/overlays.nix \
+          nix-build \
+            https://github.com/NixOS/nixpkgs/archive/$(grep rev flake.lock | sed 's/^.*: //' | sed -e 's/"//g' -e 's/,//').tar.gz \
+            --attr qemu-${v}${m}
+          for exe in ./result/bin/qemu-system-*; do
+            echo ${exe}
+            ${exe} --version
+            ${exe} --machine help
           done
         done
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Exposed packages:
 * qemu-espressif: Supports both [ESP32](https://github.com/espressif/esp-toolchain-docs/blob/main/qemu/esp32/README.md) (`"xtensa-softmmu"`) and [ESP32C3](https://github.com/espressif/esp-toolchain-docs/blob/main/qemu/esp32c3/README.md) (`"riscv32-softmmu"`) chips. Note: `nix run` will run `qemu-system-xtensa` by default.
 * qemu-esp32: Supports only ESP32.
 * qemu-esp32c3: Supports only ESP32C3.
-* qemu-[espressif|esp32|esp32c3]-minimal: As above, but has minimal qemu features based on the minimal qemu version in nixpkgs and a smaller closure.
 
 The default output of this flake is a nixpkgs overlay that adds these packages.
 

--- a/default.nix
+++ b/default.nix
@@ -2,14 +2,4 @@ final: prev: {
   qemu-espressif = final.callPackage ./packages/qemu-espressif { };
   qemu-esp32 = final.callPackage ./packages/qemu-espressif { enableEsp32c3 = false; };
   qemu-esp32c3 = final.callPackage ./packages/qemu-espressif { enableEsp32 = false; };
-
-  qemu-espressif-minimal = final.callPackage ./packages/qemu-espressif { minimal = true; };
-  qemu-esp32-minimal = final.callPackage ./packages/qemu-espressif {
-    enableEsp32c3 = false;
-    minimal = true;
-  };
-  qemu-esp32c3-minimal = final.callPackage ./packages/qemu-espressif {
-    enableEsp32 = false;
-    minimal = true;
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -41,14 +41,10 @@
             "qemu-system-riscv32" = [ "esp32c3" ];
           };
 
-          isMinimal = lib.strings.hasSuffix "-minimal" pkg.pname;
-          pnameBase = lib.strings.removeSuffix "-minimal" pkg.pname;
-
           mkCheckVersion =
             exe: "echo ${lib.getExe' pkg exe}\n${lib.getExe' pkg exe} --version | grep '${pkg.version}'\n";
           mkCheckMinimal =
-            exe:
-            "${lib.optionalString isMinimal "!"} ${lib.getExe' pkg exe} --display help | grep -v -e 'Available\\|none\\|dbus'\n";
+            exe: "! ${lib.getExe' pkg exe} --display help | grep -v -e 'Available\\|none\\|dbus'\n";
           mkCheckMachines =
             exe:
             lib.concatMapStrings (
@@ -58,7 +54,7 @@
         in
         pkgs.runCommand "check-${pkg.name}" { } ''
           echo ${pkg.pname}
-          ${lib.concatMapStrings concatChecks executablesPerVariant.${pnameBase}}
+          ${lib.concatMapStrings concatChecks executablesPerVariant.${pkg.pname}}
           mkdir "$out"
         '';
     in
@@ -70,16 +66,6 @@
         qemu-espressif = pkgs.callPackage ./packages/qemu-espressif { };
         qemu-esp32 = pkgs.callPackage ./packages/qemu-espressif { enableEsp32c3 = false; };
         qemu-esp32c3 = pkgs.callPackage ./packages/qemu-espressif { enableEsp32 = false; };
-
-        qemu-espressif-minimal = pkgs.callPackage ./packages/qemu-espressif { minimal = true; };
-        qemu-esp32-minimal = pkgs.callPackage ./packages/qemu-espressif {
-          enableEsp32c3 = false;
-          minimal = true;
-        };
-        qemu-esp32c3-minimal = pkgs.callPackage ./packages/qemu-espressif {
-          enableEsp32 = false;
-          minimal = true;
-        };
       });
 
       # Some simple sanity checks; for a full emulation check, see https://github.com/SFrijters/nix-qemu-esp32c3-rust-example


### PR DESCRIPTION
Recently I've been looking at the absurdly large closure size because the default qemu package in nixpkgs pulls in the world by default.

I've added minimal variants of the build based on the minimal qemu package in nixpkgs, but I can't really see a use case for the large build in the context of these esp microcontrollers, and I think the full build with our own `configureFlags` overrides is kind of janky, so I would like to make the minimal build the default and only available version in this flake.