### PR TITLE
Remove workarounds for long socket paths

### DIFF
--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -12,17 +12,6 @@ on:
 
 env:
   CLICOLOR_FORCE: 1
-  # This is yet another workaround for socket paths that are too long in the test suite, e.g.
-  # /nix/var/nix/builds/nix-build-qemu-esp32-9.2.2-20250817.drv-4988-2517995168/netdev-socket.VCDKB3/su_reconnect
-  # where 'su' is already shortened from 'stream_unix' via a substitution in the build.
-  #
-  # Before nix v2.30, this was
-  # /private/tmp/nix-build-qemu-esp32-9.2.2-unstable-2025-06-24.drv-0/netdev-socket.Q7TX92/stream_unix_reconnect
-  # The new default from nix v2.30 onwards is $NIX_STATE_DIR/builds,
-  # i.e. /nix/var/nix/builds . Just shrink that path by using /nix/b .
-  #
-  # TODO: Remove this after nix v2.32: https://github.com/NixOS/nix/pull/13839
-  NIX_CONFIG: "build-dir = /nix/b"
 
 jobs:
   nix-flake-check:

--- a/packages/qemu-espressif/default.nix
+++ b/packages/qemu-espressif/default.nix
@@ -73,8 +73,7 @@ let
   # That way we still get the fancy version in the --version check,
   # but we keep the internal MAJOR/MINOR/MICRO versions numerical.
   #
-  # Also: do not make this string too long in general or it will break
-  # on macos GitHub runners, see workaround below.
+  # Also: do not make this string too long in general or it will break on macos GitHub runners
   version = "9.2.2-20250817";
 
   mainProgram = if (!esp32Support) then "qemu-system-riscv32" else "qemu-system-xtensa";
@@ -157,15 +156,6 @@ qemu'.overrideAttrs (
         substituteInPlace meson.build \
           --replace-fail "config_host_data.set('QEMU_VERSION_MICRO', meson.project_version().split('.')[2])" \
                          "config_host_data.set('QEMU_VERSION_MICRO', meson.project_version().split('.')[2].split('-')[0])"
-
-        # Workaround for errors on (macos) GitHub actions runners:
-        # ERROR:../tests/qtest/netdev-socket.c:203:test_stream_unix_reconnect: assertion failed (resp == "st0: index=0,type=stream,listening\r\n"):
-        # ("st0: index=0,type=stream,error: UNIX socket path '/private/tmp/nix-build-qemu-esp32-9.2.2-unstable-2025-06-24.drv-0/netdev-socket.Q7TX92/stream_unix_reconnect'
-        #  is too long\r\n" == "st0: index=0,type=stream,listening\r\n")
-        # We can't really do anything about how nix makes its temp dirs, but we can slightly shrink the final socket name(s):
-        # TODO: Remove this when nix 2.32 is available: https://github.com/NixOS/nix/pull/13839
-        substituteInPlace tests/qtest/netdev-socket.c \
-          --replace-fail "/stream_unix" "/su"
       ''
       + (
         if enableTests then


### PR DESCRIPTION
The cachix/install-nix-action@v31 now uses nix 2.32.0, which fixes the issue: https://discourse.nixos.org/t/nix-2-32-0-released/70528